### PR TITLE
Add Combine

### DIFF
--- a/Sources/ObservableNetworking/Protocols/Network.swift
+++ b/Sources/ObservableNetworking/Protocols/Network.swift
@@ -7,10 +7,17 @@
 
 import Foundation
 import RxSwift
+import Combine
 
 public protocol Network {
     // RxSwift
     func request(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> Observable<Result<Data, NetworkError>>
     func authenticatedRequest(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> Observable<Result<Data, NetworkError>>
+
+    // Combine
+    @available(iOS 13.0, *)
+    func request(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> AnyPublisher<Data, NetworkError>
+    @available(iOS 13.0, *)
+    func authenticatedRequest(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> AnyPublisher<Data, NetworkError>
 }
 

--- a/Sources/ObservableNetworking/Protocols/Session.swift
+++ b/Sources/ObservableNetworking/Protocols/Session.swift
@@ -6,17 +6,26 @@
 //
 
 import Foundation
+import Combine
 
 /// Protocol that allows dependecy injection for the express purpose of mocking `URLSession` during testing. This should not be used elsewhere
 public protocol Session {
     typealias DataTaskResult = (Data?, URLResponse?, Error?) -> Void
     func dataTask(with request: NSURLRequest, completionHandler: @escaping DataTaskResult) -> DataTask
+
+    @available(iOS 13.0, *)
+    func dataTaskPublisher<T: TaskPublisher>(for request: URLRequest) -> T
 }
 
 // Make URLSession connform to Session protocol
 extension URLSession: Session {
     public func dataTask(with request: NSURLRequest, completionHandler: @escaping DataTaskResult) -> DataTask {
         return dataTask(with: request, completionHandler: completionHandler) as DataTask
+    }
+
+    @available(iOS 13.0, *)
+    public func dataTaskPublisher<T: TaskPublisher>(for request: URLRequest) -> T {
+        return dataTaskPublisher(for: request) as T
     }
 }
 
@@ -27,3 +36,15 @@ public protocol DataTask {
 
 // Make URLSessionDataTask conform to DataTask protocol
 extension URLSessionDataTask: DataTask {}
+
+/// Protocol that allows dependecy injection for the express purpose of mocking `URLSession` during testing. This should not be used elsewhere
+@available(iOS 13.0, *)
+public protocol TaskPublisher: Publisher {
+}
+
+// Make DataTaskPublisher conform to TaskPublisher protocol
+@available(iOS 13.0, *)
+extension URLSession.DataTaskPublisher: TaskPublisher {}
+
+@available(iOS 13.0, *)
+extension AnyPublisher: TaskPublisher {}

--- a/Tests/ObservableNetworkingTests/MockURLSession.swift
+++ b/Tests/ObservableNetworkingTests/MockURLSession.swift
@@ -49,7 +49,7 @@ class MockURLSession: Session {
     @available(iOS 13.0, *)
     func dataTaskPublisher<T>(for request: URLRequest) -> T where T : TaskPublisher {
         lastURL = request.url
-        return MockDataTaskPublisher() as! T
+        return MockDataTaskPublisher().eraseToAnyPublisher() as! T
     }
 
     private func createCookieHeader(for url: URL?) -> [String : String] {

--- a/Tests/ObservableNetworkingTests/MockURLSession.swift
+++ b/Tests/ObservableNetworkingTests/MockURLSession.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ObservableNetworking
+import Combine
 
 class MockURLSession: Session {
 
@@ -45,6 +46,12 @@ class MockURLSession: Session {
         return dataTask
     }
 
+    @available(iOS 13.0, *)
+    func dataTaskPublisher<T>(for request: URLRequest) -> T where T : TaskPublisher {
+        lastURL = request.url
+        return MockDataTaskPublisher() as! T
+    }
+
     private func createCookieHeader(for url: URL?) -> [String : String] {
         guard let cookieURL = url else { return [:] }
 
@@ -69,4 +76,28 @@ class MockURLSessionDataTask: DataTask {
     func resume() {
         resumeWasCalled = true
     }
+}
+
+class MockDataTaskPublisher: TaskPublisher {
+    typealias Output = Data
+    typealias Failure = NetworkError
+
+    @available(iOS 13.0, *)
+    func receive<S>(subscriber: S) where S : Subscriber, MockDataTaskPublisher.Failure == S.Failure, MockDataTaskPublisher.Output == S.Input {}
+}
+
+@available(iOS 13.0, *)
+extension Data: Subscriber {
+    public typealias Input = Self
+    public typealias Failure = NetworkError
+
+    public var combineIdentifier: CombineIdentifier {
+        CombineIdentifier()
+    }
+
+    public func receive(subscription: Subscription) {}
+
+    public func receive(completion: Subscribers.Completion<NetworkError>) {}
+
+    public func receive(_ input: Data) -> Subscribers.Demand { .unlimited }
 }


### PR DESCRIPTION
Adds the ability to use Apple's [Combine framework](https://developer.apple.com/documentation/combine) to make observable network requests when using iOS 13.0 or greater (the Combine framework is only available on iOS 13.0 and greater).

The method signature will look identical to those using RxSwift, but will return `AnyPublisher<Data, NetworkError>` allowing for smoother transitions for those starting with the RxSwift versions and migrating to Combine.