### PR TITLE
Update method signatures

### DIFF
--- a/Sources/ObservableNetworking/NetworkManager.swift
+++ b/Sources/ObservableNetworking/NetworkManager.swift
@@ -97,7 +97,7 @@ public final class NetworkManager: Network {
                 return Fail(error: error).eraseToAnyPublisher()
             }
 
-        let taskPublisher: AnyPublisher<Data, NetworkError> = session.dataTaskPublisher(for: request)
+        let taskPublisher: AnyPublisher<Data, NetworkError> = session.dataTaskPublisher(for: request as NSURLRequest)
         return taskPublisher
             .mapError { .failure(message: $0.localizedDescription) }
             .flatMap(maxPublishers: .max(1)) { CurrentValueSubject<Data, NetworkError>($0) }

--- a/Sources/ObservableNetworking/Protocols/Session.swift
+++ b/Sources/ObservableNetworking/Protocols/Session.swift
@@ -14,18 +14,18 @@ public protocol Session {
     func dataTask(with request: NSURLRequest, completionHandler: @escaping DataTaskResult) -> DataTask
 
     @available(iOS 13.0, *)
-    func dataTaskPublisher<T: TaskPublisher>(for request: URLRequest) -> T
+    func dataTaskPublisher<T: TaskPublisher>(for request: NSURLRequest) -> T
 }
 
 // Make URLSession connform to Session protocol
 extension URLSession: Session {
     public func dataTask(with request: NSURLRequest, completionHandler: @escaping DataTaskResult) -> DataTask {
-        return dataTask(with: request, completionHandler: completionHandler) as DataTask
+        dataTask(with: request as URLRequest, completionHandler: completionHandler) as DataTask
     }
 
     @available(iOS 13.0, *)
-    public func dataTaskPublisher<T: TaskPublisher>(for request: URLRequest) -> T {
-        return dataTaskPublisher(for: request) as T
+    public func dataTaskPublisher<T: TaskPublisher>(for request: NSURLRequest) -> T {
+        dataTaskPublisher(for: request as URLRequest) as! T
     }
 }
 
@@ -39,12 +39,12 @@ extension URLSessionDataTask: DataTask {}
 
 /// Protocol that allows dependecy injection for the express purpose of mocking `URLSession` during testing. This should not be used elsewhere
 @available(iOS 13.0, *)
-public protocol TaskPublisher: Publisher {
-}
+public protocol TaskPublisher: Publisher {}
 
 // Make DataTaskPublisher conform to TaskPublisher protocol
 @available(iOS 13.0, *)
 extension URLSession.DataTaskPublisher: TaskPublisher {}
 
+// Make AnyPublisher conform to TaskPublisher protocol
 @available(iOS 13.0, *)
 extension AnyPublisher: TaskPublisher {}

--- a/Tests/ObservableNetworkingTests/MockURLSession.swift
+++ b/Tests/ObservableNetworkingTests/MockURLSession.swift
@@ -47,7 +47,7 @@ class MockURLSession: Session {
     }
 
     @available(iOS 13.0, *)
-    func dataTaskPublisher<T>(for request: URLRequest) -> T where T : TaskPublisher {
+    func dataTaskPublisher<T>(for request: NSURLRequest) -> T where T : TaskPublisher {
         lastURL = request.url
         return MockDataTaskPublisher().eraseToAnyPublisher() as! T
     }


### PR DESCRIPTION
Update the method signatures from the service protocol to avoid an infinite loop and crash. The parameter was changed to an `NSURLRequest` (for both Rx and Combine) instead of the `URLRequest` taken by the `URLSession` implementations.