### PR TITLE
Support all Combine platforms

### DIFF
--- a/Sources/ObservableNetworking/NetworkManager.swift
+++ b/Sources/ObservableNetworking/NetworkManager.swift
@@ -48,12 +48,12 @@ public final class NetworkManager: Network {
         dataRequest(method: method, endpoint: endpoint, parameters: parameters, headers: authenticatedHeaders(headers), requiresAuthentication: true)
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     public func request(method: HTTPMethod, endpoint: String, parameters: [String : Any]? = nil, headers: [String : String]? = nil) -> AnyPublisher<Data, NetworkError> {
            dataRequest(method: method, endpoint: endpoint, parameters: parameters, headers: defaultHeaders(headers))
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     public func authenticatedRequest(method: HTTPMethod, endpoint: String, parameters: [String : Any]? = nil, headers: [String : String]? = nil) -> AnyPublisher<Data, NetworkError> {
            dataRequest(method: method, endpoint: endpoint, parameters: parameters, headers: authenticatedHeaders(headers))
     }
@@ -90,7 +90,7 @@ public final class NetworkManager: Network {
         return result
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     private func dataRequest(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: Header?) -> AnyPublisher<Data, NetworkError> {
         guard let request = generateRequest(method: method, endpoint: endpoint, parameters: parameters, headers: headers) else {
                 let error = NetworkError.unexpected

--- a/Sources/ObservableNetworking/Protocols/Network.swift
+++ b/Sources/ObservableNetworking/Protocols/Network.swift
@@ -15,9 +15,9 @@ public protocol Network {
     func authenticatedRequest(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> Observable<Result<Data, NetworkError>>
 
     // Combine
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func request(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> AnyPublisher<Data, NetworkError>
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func authenticatedRequest(method: HTTPMethod, endpoint: String, parameters: [String : Any]?, headers: [String : String]?) -> AnyPublisher<Data, NetworkError>
 }
 

--- a/Sources/ObservableNetworking/Protocols/Session.swift
+++ b/Sources/ObservableNetworking/Protocols/Session.swift
@@ -13,7 +13,7 @@ public protocol Session {
     typealias DataTaskResult = (Data?, URLResponse?, Error?) -> Void
     func dataTask(with request: NSURLRequest, completionHandler: @escaping DataTaskResult) -> DataTask
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func dataTaskPublisher<T: TaskPublisher>(for request: NSURLRequest) -> T
 }
 
@@ -23,7 +23,7 @@ extension URLSession: Session {
         dataTask(with: request as URLRequest, completionHandler: completionHandler) as DataTask
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     public func dataTaskPublisher<T: TaskPublisher>(for request: NSURLRequest) -> T {
         dataTaskPublisher(for: request as URLRequest) as! T
     }
@@ -38,13 +38,13 @@ public protocol DataTask {
 extension URLSessionDataTask: DataTask {}
 
 /// Protocol that allows dependecy injection for the express purpose of mocking `URLSession` during testing. This should not be used elsewhere
-@available(iOS 13.0, *)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
 public protocol TaskPublisher: Publisher {}
 
 // Make DataTaskPublisher conform to TaskPublisher protocol
-@available(iOS 13.0, *)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
 extension URLSession.DataTaskPublisher: TaskPublisher {}
 
 // Make AnyPublisher conform to TaskPublisher protocol
-@available(iOS 13.0, *)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
 extension AnyPublisher: TaskPublisher {}

--- a/Tests/ObservableNetworkingTests/MockURLSession.swift
+++ b/Tests/ObservableNetworkingTests/MockURLSession.swift
@@ -46,7 +46,7 @@ class MockURLSession: Session {
         return dataTask
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func dataTaskPublisher<T>(for request: NSURLRequest) -> T where T : TaskPublisher {
         lastURL = request.url
         return MockDataTaskPublisher().eraseToAnyPublisher() as! T
@@ -82,11 +82,11 @@ class MockDataTaskPublisher: TaskPublisher {
     typealias Output = Data
     typealias Failure = NetworkError
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func receive<S>(subscriber: S) where S : Subscriber, MockDataTaskPublisher.Failure == S.Failure, MockDataTaskPublisher.Output == S.Input {}
 }
 
-@available(iOS 13.0, *)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
 extension Data: Subscriber {
     public typealias Input = Self
     public typealias Failure = NetworkError

--- a/Tests/ObservableNetworkingTests/NetworkManagerTests.swift
+++ b/Tests/ObservableNetworkingTests/NetworkManagerTests.swift
@@ -207,7 +207,7 @@ final class NetworkManagerTests: XCTestCase {
 
     // MARK: - Combine Tests
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func testCombinePostRequetInEnvironments() {
         MockEnvironment.allCases.forEach { environment in
             let endpoint = "combine"
@@ -235,7 +235,7 @@ final class NetworkManagerTests: XCTestCase {
         }
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func testCombineGetRequestInEnvironments() {
         MockEnvironment.allCases.forEach { environment in
             let params = [ "userID": "1234567"]
@@ -264,7 +264,7 @@ final class NetworkManagerTests: XCTestCase {
         }
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func testCombineAuthenticatedPostFaileWithNoCookie() {
         MockEnvironment.allCases.forEach { environment in
             let endpoint = "crashtastic"
@@ -286,7 +286,7 @@ final class NetworkManagerTests: XCTestCase {
         }
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func testCombineAuthenticatedPostRequestInEnvironments() {
         MockEnvironment.allCases.forEach { environment in
             let endpoint = "something"
@@ -325,7 +325,7 @@ final class NetworkManagerTests: XCTestCase {
         }
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
     func testCombineAuthenticatedGetRequestInEnvironments() {
         MockEnvironment.allCases.forEach { environment in
             let params = [ "userID": "1234567"]


### PR DESCRIPTION
Updates to include all of the different Apple platforms that support Combine in the `available` check.