### PR TITLE
Fix crash when using Combine

### DIFF
--- a/Sources/ObservableNetworking/NetworkManager.swift
+++ b/Sources/ObservableNetworking/NetworkManager.swift
@@ -97,10 +97,8 @@ public final class NetworkManager: Network {
                 return Fail(error: error).eraseToAnyPublisher()
             }
 
-        let taskPublisher: AnyPublisher<Data, NetworkError> = session.dataTaskPublisher(for: request as NSURLRequest)
-        return taskPublisher
+        return session.dataTaskPublisher(for: request as NSURLRequest)
             .mapError { .failure(message: $0.localizedDescription) }
-            .flatMap(maxPublishers: .max(1)) { CurrentValueSubject<Data, NetworkError>($0) }
             .eraseToAnyPublisher()
     }
 

--- a/Tests/ObservableNetworkingTests/MockURLSession.swift
+++ b/Tests/ObservableNetworkingTests/MockURLSession.swift
@@ -47,9 +47,9 @@ class MockURLSession: Session {
     }
 
     @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, macCatalyst 13.0, *)
-    func dataTaskPublisher<T>(for request: NSURLRequest) -> T where T : TaskPublisher {
+    func dataTaskPublisher(for request: NSURLRequest) -> AnyPublisher<Data, NetworkError> {
         lastURL = request.url
-        return MockDataTaskPublisher().eraseToAnyPublisher() as! T
+        return MockDataTaskPublisher().eraseToAnyPublisher()
     }
 
     private func createCookieHeader(for url: URL?) -> [String : String] {
@@ -78,7 +78,7 @@ class MockURLSessionDataTask: DataTask {
     }
 }
 
-class MockDataTaskPublisher: TaskPublisher {
+class MockDataTaskPublisher: Publisher {
     typealias Output = Data
     typealias Failure = NetworkError
 


### PR DESCRIPTION
Fixes crash that was occurring due to force-casting objects that could not be cast. This makes a slight change to the `Session` protocol and removes the protocols and conformances that turned out to be unnecessary. 